### PR TITLE
Run hugo before packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,5 +45,5 @@ install:
 	cp -R public/* "${DESTDIR}${INSTALL_DIR}"
 
 .PHONY: package
-package:
+package: all
 	bash support/package.sh

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+infrahouse-com (0.1.0-1build3) jammy; urgency=medium
+
+  * commit event. see changes history in git log
+
+ -- Oleksandr Kuzminskyi <aleks@infrahouse.com>  Sat, 19 Aug 2023 14:59:34 -0700
+
 infrahouse-com (0.1.0-1build2) jammy; urgency=medium
 
   * commit event. see changes history in git log


### PR DESCRIPTION
hugo generates html files in public/* that `make package` uses to build a
package file.
